### PR TITLE
Update LICENSE.txt to consistently use open source license.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,3 @@
-This work by Mozilla is licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License.
+This work by Mozilla is licensed under a Creative Commons Attribution 4.0 International License.
 
-A summary of the terms of this license is available at http://creativecommons.org/licenses/by-nd/4.0/ and its detailed terms at http://creativecommons.org/licenses/by-nd/4.0/legalcode.
+A summary of the terms of this license is available at http://creativecommons.org/licenses/by/4.0/ and its detailed terms at http://creativecommons.org/licenses/by/4.0/legalcode.


### PR DESCRIPTION
Currently, the text in LICENSE.txt says that we are using CC-BY-NC-ND (non-commercial, no derivatives), but the URLs are for CC-BY-ND (no derivatives). And neither of these are open source licenses. 

Given that Mozilla is committed to open source, and that we want these practices to be widely adopted including inside companies, we should switch to using the simplest CC license, the Attribution license (CC-BY), which is also an open source license.
